### PR TITLE
Remove JSX dependency

### DIFF
--- a/src/react-selectize.js
+++ b/src/react-selectize.js
@@ -89,9 +89,9 @@ var ReactSelectize = React.createClass({
 
   render: function () {
     var classes = this.props.classes;
-    return <div className={classes && classes.length > 0 ? classes.join(' ') : ''}>
-      <label htmlFor={this.props.selectId}>{this.props.label}</label>
-      <select id={this.props.selectId} placeholder={this.props.placeholder}></select>
-    </div>
+    return React.createElement("div", {className: classes && classes.length > 0 ? classes.join(' ') : ''}, 
+      React.createElement("label", {htmlFor: this.props.selectId}, this.props.label), 
+      React.createElement("select", {id: this.props.selectId, placeholder: this.props.placeholder})
+    )
   }
 });

--- a/src/react-selectize.js
+++ b/src/react-selectize.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 /* React selectize wrapper */
 var ReactSelectize = React.createClass({
 


### PR DESCRIPTION
Removing JSX dependency makes it easier to use it with Node + require (webpack, etc) without running through a preprocessor. Quite a few other React component take this same route.
